### PR TITLE
feat: remove runtime dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --features unstable
+        args: --features runtime

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Experimental cooperative cancellation for async-std"
 
 [dependencies]
 pin-project-lite = "0.1.0"
-async-std = { path = "../async-std", version = "1.4.0", default-features = false, features = ["unstable"]}
+async-std = { version = "1.4.0", default-features = false, features = ["unstable"]}
 
 [features]
 runtime = ["async-std/default"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,7 @@ description = "Experimental cooperative cancellation for async-std"
 
 [dependencies]
 pin-project-lite = "0.1.0"
-async-std = { version = "1.4.0", default-features = false, features = ["unstable"]}
+async-std = { path = "../async-std", version = "1.4.0", default-features = false, features = ["unstable"]}
+
+[features]
+runtime = ["async-std/default"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,4 @@ description = "Experimental cooperative cancellation for async-std"
 
 [dependencies]
 pin-project-lite = "0.1.0"
-async-std = "1.0"
-
-[features]
-unstable = ["async-std/unstable"]
+async-std = { version = "1.4.0", default-features = false, features = ["unstable"]}


### PR DESCRIPTION
The runtime is only needed for tests. Once https://github.com/async-rs/async-std/pull/647 is merged, this should allow for runtime agonstic usage, without enabling the async-std runtime.