### PR TITLE
Add extension methods for using a StopToken, and use Result instead of Option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stop-token"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ description = "Experimental cooperative cancellation for async-std"
 
 [dependencies]
 pin-project-lite = "0.1.0"
-async-std = "1.0"
+async-std = { version = "1.0", features = ["unstable"] }
 
 [features]
 unstable = ["async-std/unstable"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,3 +230,17 @@ pub trait WithStopTokenExt: Future {
         }
     }
 }
+
+impl<S> WithStopTokenStreamExt for S where S: Stream {}
+
+pub trait WithStopTokenStreamExt: Stream {
+    fn with_stop_token(self, stop_token: &StopToken) -> StopStream<Self>
+    where
+        Self: Sized,
+    {
+        StopStream {
+            stop_token: stop_token.clone(),
+            stream: self,
+        }
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use async_std::{prelude::*, task, sync::channel};
+use async_std::{prelude::*, sync::channel, task};
 
 use stop_token::StopSource;
 
@@ -13,13 +13,14 @@ fn smoke() {
             let stop_token = stop_source.stop_token();
             let receiver = receiver.clone();
             async move {
-            let mut xs = Vec::new();
-            let mut stream = stop_token.stop_stream(receiver);
-            while let Some(x) = stream.next().await {
-                xs.push(x)
+                let mut xs = Vec::new();
+                let mut stream = stop_token.stop_stream(receiver);
+                while let Some(x) = stream.next().await {
+                    xs.push(x)
+                }
+                xs
             }
-            xs
-        }});
+        });
         sender.send(1).await;
         sender.send(2).await;
         sender.send(3).await;


### PR DESCRIPTION
I found myself writing the following code often:
```rust
let fut = some_future();
let mut fut = stop_token.stop_future(fut);
let result = fut.await;
```
Adding an extension method makes this more readable, since a fluent style can be used:
```rust
let result = some_future().with_stop_token(&stop_token).await;
```

In addition, I often had to use `match` to check for the `None` value being returned. This make the code very verbose.
Using `Result` instead makes it possible to use the question mark style for early return upon a dropped `StopSource`.

Unfortunately this can be done only for `StopFuture` and not for `StopStream`, since streams use `Option` explicitly.
But it still remains worthwhile to use it for futures.

Oh, and one more thing: Using a `Result` makes it possible to add more types of early termination, such as via a timeout instead of via the stop token. I often find myself setting up a timeout explicitly, and it would be nice to be able to add a timeout as well via a method -- and then receive a different `Error` value to be able to match on that.

My codebase (unfortunately not Open Source at this moment) became much cleaner with these changes.
The test I added demonstrates the usage.

@matklad @dignifiedquire I'd love your feedback on this.