### PR TITLE
Support stable async-std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,3 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --features unstable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/async-rs/stop-token"
 description = "Experimental cooperative cancellation for async-std"
 
 [dependencies]
-pin-project-lite = "0.1.0"
+pin-project-lite = "0.2.0"
 async-std = "1.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stop-token"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,4 @@ description = "Experimental cooperative cancellation for async-std"
 
 [dependencies]
 pin-project-lite = "0.1.0"
-async-std = "1.0"
-
-[features]
-unstable = ["async-std/unstable"]
+async-std = "1.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,8 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use async_std::prelude::*;
-use async_std::sync::{channel, Receiver, Sender};
+
+use async_std::channel::{self, Receiver, Sender};
 use pin_project_lite::pin_project;
 
 enum Never {}
@@ -101,7 +102,7 @@ pub struct StopToken {
 
 impl Default for StopSource {
     fn default() -> StopSource {
-        let (sender, receiver) = channel::<Never>(1);
+        let (sender, receiver) = channel::bounded::<Never>(1);
 
         StopSource {
             _chan: sender,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,36 +1,40 @@
 use std::time::Duration;
 
-use async_std::{prelude::*, task, sync::channel};
+use async_std::prelude::*;
+
+use async_std::channel;
+use async_std::task;
 
 use stop_token::StopSource;
 
 #[test]
 fn smoke() {
     task::block_on(async {
-        let (sender, receiver) = channel::<i32>(10);
+        let (sender, receiver) = channel::bounded::<i32>(10);
         let stop_source = StopSource::new();
         let task = task::spawn({
             let stop_token = stop_source.stop_token();
             let receiver = receiver.clone();
             async move {
-            let mut xs = Vec::new();
-            let mut stream = stop_token.stop_stream(receiver);
-            while let Some(x) = stream.next().await {
-                xs.push(x)
+                let mut xs = Vec::new();
+                let mut stream = stop_token.stop_stream(receiver);
+                while let Some(x) = stream.next().await {
+                    xs.push(x)
+                }
+                xs
             }
-            xs
-        }});
-        sender.send(1).await;
-        sender.send(2).await;
-        sender.send(3).await;
+        });
+        sender.send(1).await.unwrap();
+        sender.send(2).await.unwrap();
+        sender.send(3).await.unwrap();
 
         task::sleep(Duration::from_millis(250)).await;
         drop(stop_source);
         task::sleep(Duration::from_millis(250)).await;
 
-        sender.send(4).await;
-        sender.send(5).await;
-        sender.send(6).await;
+        sender.send(4).await.unwrap();
+        sender.send(5).await.unwrap();
+        sender.send(6).await.unwrap();
         assert_eq!(task.await, vec![1, 2, 3]);
     })
 }


### PR DESCRIPTION
Since async-std 1.8 the API has moved and is considered stable.  Since
async-std 1.9 the old API has been removed.  This allows both versions
to still work, depending on whether this crate is built with the
"unstable" feature or not.

Unfortunately I'm not sure how to run the test for both cases.  There might be some cargo gymnastics that I'm not aware off but to test the unstable feature you need to limit async-std to < 1.9 somehow, but not do that otherwise.