### PR TITLE
Use stable async-std channels from async 1.9; this fixes the build. Drop the 'unstable' feature.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,3 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --features unstable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,4 @@ description = "Experimental cooperative cancellation for async-std"
 
 [dependencies]
 pin-project-lite = "0.1.0"
-async-std = "1.0"
-
-[features]
-unstable = ["async-std/unstable"]
+async-std = "1.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,15 +5,6 @@
 //! Experimental. The library works as is, breaking changes will bump major
 //! version, but there are no guarantees of long-term support.
 //!
-//! Additionally, this library uses unstable cargo feature feature of `async-std` and, for
-//! this reason, should be used like this:
-//!
-//! ```toml
-//! [dependencies.stop-token]
-//! version = "0.1.0"
-//! features = [ "unstable" ]
-//! ```
-//!
 //! # Motivation
 //!
 //! Rust futures come with a build-in cancellation mechanism: dropping a future
@@ -71,7 +62,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use async_std::prelude::*;
-use async_std::sync::{channel, Receiver, Sender};
+use async_std::channel::{self, Receiver, Sender};
 use pin_project_lite::pin_project;
 
 enum Never {}
@@ -101,7 +92,7 @@ pub struct StopToken {
 
 impl Default for StopSource {
     fn default() -> StopSource {
-        let (sender, receiver) = channel::<Never>(1);
+        let (sender, receiver) = channel::bounded::<Never>(1);
 
         StopSource {
             _chan: sender,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,13 +1,13 @@
 use std::time::Duration;
 
-use async_std::{prelude::*, task, sync::channel};
+use async_std::{prelude::*, task, channel};
 
 use stop_token::StopSource;
 
 #[test]
 fn smoke() {
     task::block_on(async {
-        let (sender, receiver) = channel::<i32>(10);
+        let (sender, receiver) = channel::bounded::<i32>(10);
         let stop_source = StopSource::new();
         let task = task::spawn({
             let stop_token = stop_source.stop_token();
@@ -20,17 +20,17 @@ fn smoke() {
             }
             xs
         }});
-        sender.send(1).await;
-        sender.send(2).await;
-        sender.send(3).await;
+        assert!(sender.send(1).await.is_ok());
+        assert!(sender.send(2).await.is_ok());
+        assert!(sender.send(3).await.is_ok());
 
         task::sleep(Duration::from_millis(250)).await;
         drop(stop_source);
         task::sleep(Duration::from_millis(250)).await;
 
-        sender.send(4).await;
-        sender.send(5).await;
-        sender.send(6).await;
+        assert!(sender.send(4).await.is_ok());
+        assert!(sender.send(5).await.is_ok());
+        assert!(sender.send(6).await.is_ok());
         assert_eq!(task.await, vec![1, 2, 3]);
     })
 }


### PR DESCRIPTION
This fixes #6.